### PR TITLE
Add per-IP rate limiting with reverse proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,22 @@ go run ./cmd/wired-world.go -redis=localhost:6379
 
 ## Program options
 
-- `-addr`: listen address (`:8080` by default)
-- `-redis`: Redis address `host:port` (`localhost:6379` by default)
+| Flag | Default | Description |
+|---|---|---|
+| `-addr` | `:8080` | HTTP server listen address |
+| `-redis` | `localhost:6379` | Redis address `host:port` |
+| `-behind-proxy` | `false` | Trust `X-Real-IP` / `X-Forwarded-For` headers for rate limiting |
+
+## Rate limiting
+
+`POST /post` is rate limited to **1 request per 5 seconds per IP** with a burst of 2. Exceeding the limit returns `HTTP 429` with a `Retry-After: 5` header.
+
+When running behind a reverse proxy (e.g. nginx), set `-behind-proxy=true` so the real client IP is read from `X-Real-IP` / `X-Forwarded-For` headers. Only enable this when a trusted proxy sets these headers.
+
+For nginx, ensure this is set:
+```nginx
+proxy_set_header X-Real-IP $remote_addr;
+```
 
 ## In feature
 

--- a/cmd/wired-world.go
+++ b/cmd/wired-world.go
@@ -9,15 +9,19 @@ import (
 	"os/signal"
 	"time"
 
+	"golang.org/x/time/rate"
+
 	"github.com/eva-native/wired-world/internal/handlers"
+	"github.com/eva-native/wired-world/internal/middleware"
 	"github.com/eva-native/wired-world/internal/repository"
 	"github.com/eva-native/wired-world/web"
 )
 
-var redisAddr = flag.String("redis", "localhost:6379", "Redis address host:port")
-var addr = flag.String("addr", ":8080", "HTTP server listen address")
-
 func main() {
+	redisAddr := flag.String("redis", "localhost:6379", "Redis address host:port")
+	addr := flag.String("addr", ":8080", "HTTP server listen address")
+	behindProxy := flag.Bool("behind-proxy", false, "Trust X-Real-IP / X-Forwarded-For headers for rate limiting")
+
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 
@@ -30,10 +34,13 @@ func main() {
 	defer rdb.Close()
 	log.Printf("Redis open: %s", *redisAddr)
 
+	rl := middleware.NewRateLimiter(rate.Every(5*time.Second), 2, *behindProxy)
+	go rl.Cleanup(ctx, 10*time.Minute)
+
 	mux := http.NewServeMux()
 	mux.Handle("/", http.FileServerFS(web.Content()))
 	mux.Handle("/post", handlers.AllPost(&rdb))
-	mux.Handle("POST /post", handlers.AddNewPost(&rdb))
+	mux.Handle("POST /post", rl.Middleware(handlers.AddNewPost(&rdb)))
 
 	if err := listenAndServe(ctx, *addr, mux); err != nil {
 		log.Printf("Server error: %v", err)
@@ -41,15 +48,11 @@ func main() {
 }
 
 func listenAndServe(ctx context.Context, addr string, mux *http.ServeMux) error {
-	srv := http.Server{
-		Addr:    addr,
-		Handler: mux,
-	}
+	srv := &http.Server{Addr: addr, Handler: mux}
 
 	errch := make(chan error, 1)
-
 	go func() {
-		log.Printf("Starting server on %s...", srv.Addr)
+		log.Printf("Starting server on %s...", addr)
 		if err := srv.ListenAndServe(); err != http.ErrServerClosed {
 			errch <- err
 		}
@@ -57,14 +60,13 @@ func listenAndServe(ctx context.Context, addr string, mux *http.ServeMux) error 
 
 	select {
 	case <-ctx.Done():
-		ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+		shutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-
-		err := srv.Shutdown(ctx)
-		if err != nil {
+		if err := srv.Shutdown(shutCtx); err != nil {
 			srv.Close()
+			return err
 		}
-		return err
+		return nil
 	case err := <-errch:
 		return err
 	}

--- a/compose.yml
+++ b/compose.yml
@@ -17,6 +17,7 @@ services:
     command:
       - -redis=redis:6379
       - -addr=:80
+      - -behind-proxy=true
     ports:
       - "127.0.0.1:8000:80"
     depends_on:

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,11 @@
 module github.com/eva-native/wired-world
 
-go 1.24.5
+go 1.25.0
 
-require github.com/redis/go-redis/v9 v9.18.0
+require (
+	github.com/redis/go-redis/v9 v9.18.0
+	golang.org/x/time v0.15.0
+)
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,3 +20,5 @@ github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
 go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
+golang.org/x/time v0.15.0 h1:bbrp8t3bGUeFOx08pvsMYRTCVSMk89u4tKbNOZbp88U=
+golang.org/x/time v0.15.0/go.mod h1:Y4YMaQmXwGQZoFaVFk4YpCt4FLQMYKZe9oeV/f4MSno=

--- a/internal/middleware/ratelimit.go
+++ b/internal/middleware/ratelimit.go
@@ -1,0 +1,98 @@
+package middleware
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+type ipLimiter struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
+
+type RateLimiter struct {
+	mu          sync.Mutex
+	limiters    map[string]*ipLimiter
+	r           rate.Limit
+	burst       int
+	behindProxy bool
+}
+
+func NewRateLimiter(r rate.Limit, burst int, behindProxy bool) *RateLimiter {
+	return &RateLimiter{
+		limiters:    make(map[string]*ipLimiter),
+		r:           r,
+		burst:       burst,
+		behindProxy: behindProxy,
+	}
+}
+
+func (rl *RateLimiter) get(ip string) *rate.Limiter {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	entry, ok := rl.limiters[ip]
+	if !ok {
+		entry = &ipLimiter{limiter: rate.NewLimiter(rl.r, rl.burst)}
+		rl.limiters[ip] = entry
+	}
+	entry.lastSeen = time.Now()
+	return entry.limiter
+}
+
+func (rl *RateLimiter) Cleanup(ctx context.Context, ttl time.Duration) {
+	ticker := time.NewTicker(ttl)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			rl.mu.Lock()
+			for ip, entry := range rl.limiters {
+				if time.Since(entry.lastSeen) > ttl {
+					delete(rl.limiters, ip)
+				}
+			}
+			rl.mu.Unlock()
+		}
+	}
+}
+
+// clientIP extracts the real client IP. When behindProxy is true it reads
+// X-Real-IP first, then the leftmost entry of X-Forwarded-For, falling back
+// to RemoteAddr. Only enable behindProxy when a trusted proxy sets these headers.
+func clientIP(r *http.Request, behindProxy bool) string {
+	if behindProxy {
+		if ip := r.Header.Get("X-Real-IP"); ip != "" {
+			return ip
+		}
+		if fwd := r.Header.Get("X-Forwarded-For"); fwd != "" {
+			if i := strings.IndexByte(fwd, ','); i != -1 {
+				return strings.TrimSpace(fwd[:i])
+			}
+			return strings.TrimSpace(fwd)
+		}
+	}
+	ip, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return ip
+}
+
+func (rl *RateLimiter) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !rl.get(clientIP(r, rl.behindProxy)).Allow() {
+			w.Header().Set("Retry-After", "5")
+			http.Error(w, http.StatusText(http.StatusTooManyRequests), http.StatusTooManyRequests)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}


### PR DESCRIPTION
## Summary

- **Rate limiting**: per-IP token bucket on `POST /post` (1 req/5s, burst 2) via `golang.org/x/time/rate`; returns 429 with `Retry-After: 5`
- **Proxy support**: `-behind-proxy` flag reads real client IP from `X-Real-IP` / `X-Forwarded-For` when set; safe by default (headers ignored without the flag)
- `compose.yml` sets `-behind-proxy=true` for the nginx deployment

## New files

- `internal/middleware/ratelimit.go` — per-IP rate limiter with stale entry cleanup via `time.NewTicker`

## Test plan

- [ ] `go build ./...` compiles cleanly
- [ ] `POST /post` 3x rapidly → first 2 succeed, third returns 429
- [ ] Wait 5s, post again → succeeds
- [ ] With `-behind-proxy=true` and `X-Real-IP` header set → rate limits by header IP, not proxy IP

🤖 Generated with [Claude Code](https://claude.com/claude-code)