### PR TITLE
Add CI/CD GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: gofmt check
+        run: test -z "$(gofmt -l .)"
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test ./...
+
+      - name: Build
+        run: go build -tags embed ./cmd/wired-world.go

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,39 @@
+name: Docker
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/eva-native/wired-world
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=semver,pattern={{version}}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/internal/data/post.go
+++ b/internal/data/post.go
@@ -33,8 +33,10 @@ func PrepareMessage(m string) string {
 
 func ValidateMessage(m string) error {
 	switch s := len(m); {
-	case s == 0: return ErrEmptyMessage
-	case s > 0x80: return ErrTooLongMessage
+	case s == 0:
+		return ErrEmptyMessage
+	case s > 0x80:
+		return ErrTooLongMessage
 	}
 	return nil
 }

--- a/web/embed.go
+++ b/web/embed.go
@@ -24,4 +24,3 @@ var tmpl = template.Must(template.ParseFS(templates, "template/*.tmpl"))
 func Templates() *template.Template {
 	return tmpl
 }
-

--- a/web/no_embed.go
+++ b/web/no_embed.go
@@ -17,4 +17,3 @@ var tmpl = template.Must(template.ParseFS(os.DirFS("./web/template"), "*.tmpl"))
 func Templates() *template.Template {
 	return tmpl
 }
-


### PR DESCRIPTION
## Summary

- CI workflow runs on every push and PR: gofmt check, go vet, go test, go build
- Docker workflow pushes to `ghcr.io/eva-native/wired-world` on merges to `main` (`:latest`) and `v*` tags (`:<version>`)
- No extra secrets needed — uses built-in `GITHUB_TOKEN` with `packages: write` permission

## Test plan

- [x] Push to any branch → CI workflow runs (fmt/vet/test/build)
- [ ] Open a PR → CI runs on the PR
- [ ] Merge to main → Docker workflow pushes `:latest` to GHCR
- [ ] Push `v1.0.0` tag → Docker workflow pushes `:1.0.0` to GHCR
- [ ] Check `https://github.com/eva-native/wired-world/pkgs/container/wired-world` for published images

🤖 Generated with [Claude Code](https://claude.com/claude-code)